### PR TITLE
fix: Remove EOT font preload to resolve browser compatibility warnings

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,49 +1,66 @@
 // Plugins
-import vue from '@vitejs/plugin-vue'
-import vuetify, { transformAssetUrls } from 'vite-plugin-vuetify'
-import ViteFonts from 'unplugin-fonts/vite'
+import vue from "@vitejs/plugin-vue";
+import vuetify, { transformAssetUrls } from "vite-plugin-vuetify";
+import ViteFonts from "unplugin-fonts/vite";
 
 // Utilities
-import { defineConfig } from 'vite'
-import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from "vite";
+import { fileURLToPath, URL } from "node:url";
+
+// カスタムプラグインでeotフォントのpreloadを除去
+function removeEotPreload() {
+  return {
+    name: "remove-eot-preload",
+    transformIndexHtml(html) {
+      // eotフォントのpreloadタグを除去
+      return html.replace(
+        /<link rel="preload" as="font" type="font\/eot"[^>]*>/g,
+        ""
+      );
+    },
+  };
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     vue({
-      template: { transformAssetUrls }
+      template: { transformAssetUrls },
     }),
     // https://github.com/vuetifyjs/vuetify-loader/tree/master/packages/vite-plugin#readme
     vuetify({
       autoImport: true,
       styles: {
-        configFile: 'src/styles/settings.scss',
+        configFile: "src/styles/settings.scss",
       },
     }),
     ViteFonts({
       google: {
-        families: [{
-          name: 'Roboto',
-          styles: 'wght@100;300;400;500;700;900',
-        }],
+        families: [
+          {
+            name: "Roboto",
+            styles: "wght@100;300;400;500;700;900",
+          },
+        ],
       },
     }),
+    removeEotPreload(), // eotフォントのpreloadを除去
   ],
-  define: { 'process.env': {} },
+  define: { "process.env": {} },
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
     extensions: [
-      '.js',
-      '.json',
-      '.jsx',
-      '.mjs',
-      '.ts',
-      '.tsx',
-      '.vue',
-      '.css',
-      '.ttf',
+      ".js",
+      ".json",
+      ".jsx",
+      ".mjs",
+      ".ts",
+      ".tsx",
+      ".vue",
+      ".css",
+      ".ttf",
     ],
   },
   server: {
@@ -53,12 +70,12 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: {
-          'vuetify': ['vuetify'],
-          'vendor': ['vue', 'vue-router', 'pinia'],
-        }
-      }
+          vuetify: ["vuetify"],
+          vendor: ["vue", "vue-router", "pinia"],
+        },
+      },
     },
     chunkSizeWarningLimit: 1000,
     assetsInlineLimit: 4096,
-  }
-})
+  },
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,7 +14,7 @@ function removeEotPreload() {
     transformIndexHtml(html) {
       // eotフォントのpreloadタグを除去
       return html.replace(
-        /<link rel="preload" as="font" type="font\/eot"[^>]*>/g,
+        /<link rel="preload" as="font" (type="font\/eot"|type="application\/vnd\.ms-fontobject")[^>]*>|<link rel="preload" as="font" href="[^"]+\.eot"[^>]*>/g,
         ""
       );
     },


### PR DESCRIPTION
- Add custom Vite plugin to remove EOT font preload tags from HTML
- EOT format is legacy and not supported by modern browsers
- This prevents console warnings and improves Lighthouse scores
- Affects Material Design Icons font loading optimization